### PR TITLE
supported activerecord 5

### DIFF
--- a/lib/slavery.rb
+++ b/lib/slavery.rb
@@ -68,8 +68,8 @@ module Slavery
     def slaveryable?
       @base_transaction_depth ||= begin
         defined?(ActiveSupport::TestCase) &&
-        ActiveSupport::TestCase.respond_to?(:use_transactional_fixtures) &&
-        ActiveSupport::TestCase.try(:use_transactional_fixtures) ? 1 : 0
+        ActiveSupport::TestCase.respond_to?(:use_transactional_tests) &&
+        ActiveSupport::TestCase.try(:use_transactional_tests) ? 1 : 0
       end
       inside_transaction = master_connection.open_transactions > @base_transaction_depth
       raise Error.new('on_slave cannot be used inside transaction block!') if inside_transaction

--- a/lib/slavery/relation.rb
+++ b/lib/slavery/relation.rb
@@ -11,11 +11,11 @@ class ActiveRecord::Relation
   end
 
   # Supports queries like User.on_slave.count
-  def calculate_with_slavery(operation, column_name, options = {})
+  def calculate_with_slavery(operation, column_name)
     if slavery_target == :slave
-      Slavery.on_slave { calculate_without_slavery(operation, column_name, options) }
+      Slavery.on_slave { calculate_without_slavery(operation, column_name) }
     else
-      calculate_without_slavery(operation, column_name, options)
+      calculate_without_slavery(operation, column_name)
     end
   end
 

--- a/lib/slavery/relation.rb
+++ b/lib/slavery/relation.rb
@@ -1,24 +1,25 @@
-class ActiveRecord::Relation
+module WithSlavery
   attr_accessor :slavery_target
 
   # Supports queries like User.on_slave.to_a
-  def exec_queries_with_slavery
+  def exec_queries
     if slavery_target == :slave
-      Slavery.on_slave { exec_queries_without_slavery }
+      Slavery.on_slave { super }
     else
-      exec_queries_without_slavery
+      super
     end
   end
 
   # Supports queries like User.on_slave.count
-  def calculate_with_slavery(operation, column_name)
+  def calculate(operation, column_name)
     if slavery_target == :slave
-      Slavery.on_slave { calculate_without_slavery(operation, column_name) }
+      Slavery.on_slave { super(operation, column_name) }
     else
-      calculate_without_slavery(operation, column_name)
+      super(operation, column_name)
     end
   end
+end
 
-  alias_method_chain :exec_queries, :slavery
-  alias_method_chain :calculate, :slavery
+class ActiveRecord::Relation
+  prepend WithSlavery
 end

--- a/slavery.gemspec
+++ b/slavery.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_runtime_dependency 'activerecord', '>= 3.0.0'
+  gem.add_runtime_dependency 'activerecord', '5.0.0.beta3'
 
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'sqlite3'

--- a/slavery.gemspec
+++ b/slavery.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_runtime_dependency 'activerecord', '5.0.0.beta3'
+  gem.add_runtime_dependency 'activerecord', '5.0.0'
 
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'sqlite3'

--- a/slavery.gemspec
+++ b/slavery.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_runtime_dependency 'activerecord', '5.0.0'
+  gem.add_runtime_dependency 'activerecord', '>= 3.0.0'
 
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'sqlite3'


### PR DESCRIPTION
- removed options argument. see https://github.com/rails/rails/commit/78dab2a8569408658542e462a957ea5a35aa4679
- used prepend
- renamed `use_transactional_fixture -> use_transactional_tests` see https://github.com/rspec/rspec-rails/issues/1549
